### PR TITLE
Autogenerate DynamoDB table name. Add `dynamodb_table_name` output

### DIFF
--- a/dynamodb.tf
+++ b/dynamodb.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "dynamodb" {
     effect  = "Allow"
     actions = ["dynamodb:*"]
 
-    resources = ["arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.dynamodb_table_name}"]
+    resources = ["arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${module.label_dynamodb.id}"]
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,3 +9,7 @@ output "s3_bucket_domain_name" {
 output "s3_bucket_arn" {
   value = "${module.s3_bucket.bucket_arn}"
 }
+
+output "dynamodb_table_name" {
+  value = "${module.label_dynamodb.id}"
+}


### PR DESCRIPTION
## what
* Autogenerate DynamoDB table name
* Add `dynamodb_table_name` output

## why
* The auto-generated table name will be used in Teleport to create the table automatically
* Use the `label` pattern to generate resource names
