### PR TITLE
Use separate Dynamo tables for cluster state and audit event logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This Terraform module provisions:
 
 * An S3 bucket for session logs in Gravitational [Teleport](https://gravitational.com/teleport)
-* A DynamoDB table to use as storage backend in Teleport
+* 2 DynamoDB tables to use as storage backend in Teleport
 
 
 ## Features

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,10 +10,18 @@ output "s3_bucket_arn" {
   value = "${module.s3_bucket.bucket_arn}"
 }
 
-output "dynamodb_table_id" {
-  value = "${module.dynamodb_table.table_id}"
+output "dynamodb_audit_table_id" {
+  value = "${module.dynamodb_audit_table.table_id}"
 }
 
-output "dynamodb_table_arn" {
-  value = "${module.dynamodb_table.table_arn}"
+output "dynamodb_audit_table_arn" {
+  value = "${module.dynamodb_audit_table.table_arn}"
+}
+
+output "dynamodb_state_table_id" {
+  value = "${module.dynamodb_state_table.table_id}"
+}
+
+output "dynamodb_state_table_arn" {
+  value = "${module.dynamodb_state_table.table_arn}"
 }

--- a/s3.tf
+++ b/s3.tf
@@ -4,7 +4,7 @@ module "s3_bucket" {
   stage                    = "${var.stage}"
   name                     = "${var.name}"
   delimiter                = "${var.delimiter}"
-  attributes               = ["${compact(concat(var.attributes, list("logs")))}"]
+  attributes               = ["${compact(concat(var.attributes, list("sessions")))}"]
   tags                     = "${var.tags}"
   prefix                   = "${var.prefix}"
   standard_transition_days = "${var.standard_transition_days}"
@@ -18,7 +18,7 @@ module "label_s3" {
   stage      = "${var.stage}"
   name       = "${var.name}"
   delimiter  = "${var.delimiter}"
-  attributes = ["${compact(concat(var.attributes, list("logs")))}"]
+  attributes = ["${compact(concat(var.attributes, list("sessions")))}"]
   tags       = "${var.tags}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -31,11 +31,6 @@ variable "tags" {
   description = "Additional tags (e.g. map('BusinessUnit`,`XYZ`)"
 }
 
-variable "region" {
-  type        = "string"
-  description = "AWS Region"
-}
-
 variable "prefix" {
   type        = "string"
   description = "S3 bucket prefix"
@@ -58,21 +53,6 @@ variable "expiration_days" {
   type        = "string"
   description = "Number of days after which to expunge the objects"
   default     = "90"
-}
-
-variable "hash_key" {
-  type    = "string"
-  default = "HashKey"
-}
-
-variable "range_key" {
-  type    = "string"
-  default = "FullPath"
-}
-
-variable "ttl_attribute" {
-  type    = "string"
-  default = "Expires"
 }
 
 variable "autoscale_write_target" {


### PR DESCRIPTION
## what
Previously, only 1 DynamoDB table was created, and that was to store the cluster state to allow for HA deployment. However, Teleport also uses a second, differently configured table to store "audit events". This PR provisions that table as well.

## why
Required for proper operation of Teleport auth service.