### PR TITLE
Teleport 4 requires stream view for cluster state table

### DIFF
--- a/dynamodb.tf
+++ b/dynamodb.tf
@@ -8,6 +8,8 @@ module "dynamodb_state_table" {
   attributes        = ["${compact(concat(var.attributes, list("cluster_state")))}"]
   tags              = "${var.tags}"
   enable_encryption = "true"
+  enable_streams    = "true"
+  stream_view_type  = "NEW_IMAGE"
   hash_key          = "HashKey"
   hash_key_type     = "S"
   range_key         = "FullPath"


### PR DESCRIPTION
## what
Enable stream view for cluster state table

## why
Required by Teleport 4.x, possibly even as early as 3.2